### PR TITLE
Add sanic-sslify

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [Sanic Gzip](https://github.com/koug44/sanic-gzip): Add compression to your Sanic endpoints with a decorator
 - [Sanic-Limiter](https://github.com/bohea/sanic-limiter): Rate limiting for sanic.
 - [Sanic-UserAgent](https://github.com/lixxu/sanic-useragent): Add `user_agent` to request
+- [Sanic-SSLify](https://github.com/dzqdzq/sanic_sslify): Forces SSL on your Sanic app. A port of Flask-SSLify.
 
 ### Caching
 - [Sanic-redis-extension](https://github.com/Relrin/sanic-redis-extension): Redis (via aioredis) support for Sanic framework 


### PR DESCRIPTION
I'm not an author of sanic-sslify, but it seems to prove useful for environments where full-featured reverse proxy running in front of an app is not available (i.e. Heroku has means for SSL, but doesn't enforce it by itself)